### PR TITLE
feat: Add support for Apple Silicon (MPS)

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,7 +101,7 @@ def get_examples(examples_dir: str = "assets/examples") -> list:
 
 def create_demo(
     model_type: str,
-    device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    device: str = "cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"),
     offload: bool = False,
 ):
 
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     @dataclasses.dataclass
     class AppArgs:
         name: Literal["flux-dev", "flux-dev-fp8", "flux-schnell", "flux-krea-dev"] = "flux-dev"
-        device: Literal["cuda", "cpu"] = "cuda" if torch.cuda.is_available() else "cpu"
+        device: Literal["cuda", "cpu", "mps"] = "cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu")
         offload: bool = dataclasses.field(
             default=False,
             metadata={

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ matplotlib
 safetensors==0.4.5
 scipy==1.10.1
 numpy==1.24.4
-onnxruntime-gpu
+onnxruntime
 # httpx==0.23.3
 git+https://github.com/openai/CLIP.git
 # --extra-index-url https://download.pytorch.org/whl/cu124

--- a/uso/flux/pipeline.py
+++ b/uso/flux/pipeline.py
@@ -257,8 +257,9 @@ class USOPipeline:
         height = 16 * (height // 16)
 
         device_type = self.device if isinstance(self.device, str) else self.device.type
+        dtype = torch.bfloat16 if device_type != "mps" else torch.float16
         with torch.autocast(
-            enabled=self.use_fp8, device_type=device_type, dtype=torch.bfloat16
+            enabled=self.use_fp8, device_type=device_type, dtype=dtype
         ):
             return self.forward(
                 prompt, width, height, guidance, num_steps, seed, **kwargs
@@ -387,4 +388,5 @@ class USOPipeline:
             return
         for model in models:
             model.cpu()
+        if torch.cuda.is_available():
             torch.cuda.empty_cache()


### PR DESCRIPTION
This commit introduces the necessary changes to allow the application to run on Apple Silicon devices using the MPS backend.

The changes include:
- Updating the device selection logic to detect and use 'mps' if available.
- Modifying the requirements to use the generic 'onnxruntime' instead of 'onnxruntime-gpu'.
- Adjusting the torch.autocast dtype to float16 for MPS, as bfloat16 support is limited.
- Making CUDA-specific calls conditional to prevent errors on non-CUDA systems.