### PR TITLE
Fix: Ensure model is moved to device after loading state dict

### DIFF
--- a/uso/flux/util.py
+++ b/uso/flux/util.py
@@ -391,7 +391,7 @@ def load_flow_model_only_lora(
                 sd[k.replace("module.", "")] = dit_state[k]
             sd.update(lora_sd)
             missing, unexpected = model.load_state_dict(sd, strict=False, assign=True)
-            model.to(str(device))
+        model.to(str(device))
         print_load_warning(missing, unexpected)
     return model
 


### PR DESCRIPTION
The `load_flow_model_only_lora` function initialized the model on the `meta` device but did not consistently move it to the target device after loading the state dictionary. This resulted in a `RuntimeError` when running on MPS devices, as some tensors remained on the `meta` device.

This commit moves the `model.to(str(device))` call to be unconditional, ensuring that the entire model is placed on the correct device after all weights are loaded. This resolves the device mismatch error.